### PR TITLE
MTP: Add support of ObjectInfoChanged Event

### DIFF
--- a/media/mtp/MtpServer.cpp
+++ b/media/mtp/MtpServer.cpp
@@ -99,6 +99,7 @@ static const MtpEventCode kSupportedEventCodes[] = {
     MTP_EVENT_STORE_ADDED,
     MTP_EVENT_STORE_REMOVED,
     MTP_EVENT_DEVICE_PROP_CHANGED,
+    MTP_EVENT_OBJECT_INFO_CHANGED,
 };
 
 MtpServer::MtpServer(IMtpDatabase* database, int controlFd, bool ptp,
@@ -257,6 +258,11 @@ void MtpServer::sendObjectAdded(MtpObjectHandle handle) {
 void MtpServer::sendObjectRemoved(MtpObjectHandle handle) {
     ALOGV("sendObjectRemoved %d\n", handle);
     sendEvent(MTP_EVENT_OBJECT_REMOVED, handle);
+}
+
+void MtpServer::sendObjectInfoChanged(MtpObjectHandle handle) {
+    ALOGV("sendObjectInfoChanged %d\n", handle);
+    sendEvent(MTP_EVENT_OBJECT_INFO_CHANGED, handle);
 }
 
 void MtpServer::sendStoreAdded(MtpStorageID id) {

--- a/media/mtp/MtpServer.h
+++ b/media/mtp/MtpServer.h
@@ -115,6 +115,7 @@ public:
 
     void                sendObjectAdded(MtpObjectHandle handle);
     void                sendObjectRemoved(MtpObjectHandle handle);
+    void                sendObjectInfoChanged(MtpObjectHandle handle);
     void                sendDevicePropertyChanged(MtpDeviceProperty property);
 
 private:


### PR DESCRIPTION
Under MTP mode, new file created at device side shown size zero at PC side
due to file information is not updated to PC in time with ObjectAdded event

Bug: 77883345
Test: 1. Take screenshot of device under MTP mode with Win10 / Linux
    2. file copy, delete, rename between PC and device
    3. file copy, delete, rename on device with adb shell command

Change-Id: If428064fb0104b53b8afd5b050a4fab4a09312f0
Merged-In: If428064fb0104b53b8afd5b050a4fab4a09312f0